### PR TITLE
Patched 🐛 Inconsistent Interpretation of HTTP Requests in twisted.web

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required for the Twisted client, obviously, but not for the procedural one.
 
-Twisted==22.2.0
+Twisted==22.4.0
 
 
 # These packages are only used for building and running tests, not for using


### PR DESCRIPTION
## Description of the change
The Twisted Web HTTP 1.1 server, located in the `twisted.web.http` module, parsed several HTTP request constructs more leniently than permitted by RFC 7230:

1. The Content-Length header value could have a `+` or `-` prefix.
1. Illegal characters were permitted in chunked extensions, such as the LF (`\n`) character.
1. Chunk lengths, which are expressed in hexadecimal format, could have a prefix of `0x`.
1. HTTP headers were stripped of all leading and trailing ASCII whitespace, rather than only space and HTAB (`\t`).

# Impact
You may be affected if:
  * You use Twisted Web's HTTP 1.1 server and/or proxy
  * You also pass requests through a different HTTP server and/or proxy

The specifics of the other HTTP parser matter. The original report notes that some versions of Apache Traffic Server and HAProxy have been vulnerable in the past. HTTP request smuggling may be a serious concern if you use a proxy to perform request validation or access control. The Twisted Web client is not affected. The HTTP 2.0 server uses a different parser, so it is not affected.


## Type of change
- [x] Bug fix

## Security

- [x] This PR has security related considerations.
on twisted in [requirements.txt](https://github.com/foxpass/divvy-client-python/blob/-/requirements.txt).
